### PR TITLE
fix(tsconfig): move isolatedModules option to tsconfig.base.json

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,6 +6,7 @@
     "declarationMap": false,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true, // isolatedModules is required by ts-jest
     "lib": [
       "ES2022",
       "DOM" // NOTE: DOM is only required to avoid errors with some transitive dependencies.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "moduleResolution": "NodeNext",
     "outDir": "./lib"
   },
-  "isolatedModules": true, // isolatedModules is required by jest-ts
   "exclude": ["__fixtures__", "__tests__", "coverage", "lib", "node_modules"],
   "include": ["src"]
 }


### PR DESCRIPTION
**Description:**

Move the `isolatedModules` option to `tsconfig.base.json` because it's used for tests as well as the production code.

**Related Issues:**

- Resolves #103 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
